### PR TITLE
feat: Registro de Ponto Backend

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 import os
 
-from app.routes import colaboradores, user_register
+from app.routes import colaboradores, user_register, registro_ponto
 from app.database import Base, engine
 from app import models
 
@@ -36,6 +36,7 @@ app.add_middleware(
 # Registra as rotas
 app.include_router(user_register.router)
 app.include_router(colaboradores.router)
+app.include_router(registro_ponto.router)
 
 # Rota principal
 @app.get("/")

--- a/app/models.py
+++ b/app/models.py
@@ -1,19 +1,27 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Date
+from datetime import datetime, date
+from sqlalchemy.orm import relationship
 from app.database import Base
 
 class Colaborador(Base): 
-    __tablename__ = "colaboradores"
+    __tablename__ = "colaborador"
 
-    id = Column(Integer, primary_key=True, index=True)
-    nome = Column(String, nullable=False)
-    cpf = Column(String, unique=True, nullable=False)
-    email = Column(String, unique=True, nullable=False)
-    senha_hash = Column(String, nullable=False)
+    id_col = Column(Integer, primary_key=True, index=True)
+    nome_col = Column(String, nullable=False)
+    cpf_col = Column(String, unique=True, nullable=False)
+    email_col = Column(String, unique=True, nullable=False)
+    senha_col = Column(String, nullable=False)
 
-class Ponto(Base):
-    __tablename__ = "ponto"
+    registros = relationship("RegistroPonto", back_populates="colaborador")
 
-    id = Column(Integer, primary_key=True, index=True)
-    fk_colaborador = Column(Integer, ForeignKey("colaboradores.id"), nullable=False)
-    entrada = Column(DateTime, nullable=False)
-    saida = Column(DateTime, nullable=True)
+class RegistroPonto(Base):
+    __tablename__ = "registro_ponto"
+
+    id_reg = Column(Integer, primary_key=True, index=True)
+    colaborador_id = Column(Integer, ForeignKey("colaborador.id_col"))
+    tipo_reg = Column(String)                                                   # "entrada" ou "saida"
+    timestamp_reg = Column(DateTime, default=datetime.utcnow)
+    data_reg = Column(Date)                                                   # Apenas a data (YYYY-MM-DD) para facilitar agrupamentos
+
+    colaborador = relationship("Colaborador", back_populates="registros")

--- a/app/routes/colaboradores.py
+++ b/app/routes/colaboradores.py
@@ -9,4 +9,4 @@ router = APIRouter()
 @router.post("/login")
 def login(login_data: LoginRequest, db: Session = Depends(get_db)):
     colaborador = login_colaborador(login_data.cpf, login_data.senha, db)
-    return {"mensagem": "Login realizado com sucesso", "nome": colaborador.nome}
+    return {"mensagem": "Login realizado com sucesso", "nome": colaborador.nome_col}

--- a/app/routes/registro_ponto.py
+++ b/app/routes/registro_ponto.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.database import get_db
+from app import schemas, services
+from app.services import registro_service
+from app.schemas import RegistroPontoDebug
+
+router = APIRouter()
+
+@router.post("/registro", response_model=schemas.RegistroPontoOut)
+def registrar_ponto_endpoint(
+    registro: schemas.RegistroPontoCreate,
+    db: Session = Depends(get_db)
+):
+    try:
+        novo_registro = registro_service.registrar_ponto(registro.colaborador_id, db)
+        return novo_registro
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=500, detail="Erro ao registrar ponto.")
+    
+# Rota de debug do controle de ponto para casos onde o ponto ultrapasse a meia noite
+@router.post("/registro/debug", response_model=schemas.RegistroPontoOut)
+def registrar_ponto_debug_endpoint(
+    dados: RegistroPontoDebug,
+    db: Session = Depends(get_db)
+):
+    try:
+        registro = registro_service.registrar_ponto_debug(
+            colaborador_id=dados.colaborador_id,
+            db=db,
+            timestamp_manual=dados.timestamp_manual
+        )
+        return registro
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=500, detail="Erro ao registrar ponto (debug).")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,6 @@
 from pydantic import BaseModel, EmailStr, field_validator
+from datetime import datetime, date
+from typing import Optional
 
 class ColaboradorCreate(BaseModel):
     nome: str
@@ -13,3 +15,23 @@ class ColaboradorCreate(BaseModel):
 class LoginRequest(BaseModel):
     cpf: str
     senha: str
+
+# Schema para entrada de dados no registro de ponto
+class RegistroPontoCreate(BaseModel):
+    colaborador_id: int
+
+# Schema para saída de dados (retorno do backend)
+class RegistroPontoOut(BaseModel):
+    id_reg: int
+    colaborador_id: int
+    tipo_reg: str
+    timestamp_reg: datetime
+    data_reg: date
+
+    class Config:
+        orm_mode = True
+
+# Schema para testes com o controle de ponto.
+class RegistroPontoDebug(BaseModel):
+    colaborador_id: int
+    timestamp_manual: Optional[datetime] = None  # Pode ser omitido

--- a/app/services/colaborador_service.py
+++ b/app/services/colaborador_service.py
@@ -5,12 +5,12 @@ from fastapi import HTTPException
 
 def login_colaborador(cpf: str, senha: str, db: Session):
     cpf = ''.join(filter(str.isdigit, cpf))  # normaliza CPF
-    colaborador = db.query(Colaborador).filter(Colaborador.cpf == cpf).first()
+    colaborador = db.query(Colaborador).filter(Colaborador.cpf_col == cpf).first()
 
     if not colaborador:
         raise HTTPException(status_code=401, detail="Colaborador não encontrado")
 
-    if not verificar_senha(senha, colaborador.senha_hash):
+    if not verificar_senha(senha, colaborador.senha_col):
         raise HTTPException(status_code=401, detail="Senha incorreta")
 
     return colaborador

--- a/app/services/registro_service.py
+++ b/app/services/registro_service.py
@@ -1,0 +1,69 @@
+from typing import Optional
+from sqlalchemy.orm import Session
+from datetime import datetime, date
+from app import models
+
+def registrar_ponto(colaborador_id: int, db: Session) -> models.RegistroPonto:
+    # Verifica se o colaborador existe
+    colaborador = db.query(models.Colaborador).filter(models.Colaborador.id_col == colaborador_id).first()
+    if not colaborador:
+        raise ValueError("Colaborador não encontrado.")
+
+    # Busca o último registro (qualquer data)
+    ultimo_registro = (
+        db.query(models.RegistroPonto)
+        .filter(models.RegistroPonto.colaborador_id == colaborador_id)
+        .order_by(models.RegistroPonto.timestamp_reg.desc())
+        .first()
+    )
+
+    # Define tipo com base no último registro
+    if not ultimo_registro or ultimo_registro.tipo_reg == "saida":
+        tipo = "entrada"
+    else:
+        tipo = "saida"
+
+    agora = datetime.now()
+
+    novo_registro = models.RegistroPonto(
+        colaborador_id=colaborador_id,
+        tipo_reg=tipo,
+        timestamp_reg=agora,
+        data_reg=agora.date()  # ainda útil para agrupamentos simples
+    )
+
+    db.add(novo_registro)
+    db.commit()
+    db.refresh(novo_registro)
+
+    return novo_registro
+
+# Função para testes com o timestamp manual, para casos de turnos que ultrapassem 1 dia.
+def registrar_ponto_debug(colaborador_id: int, db: Session, timestamp_manual: Optional[datetime] = None) -> models.RegistroPonto:
+    colaborador = db.query(models.Colaborador).filter(models.Colaborador.id_col == colaborador_id).first()
+    if not colaborador:
+        raise ValueError("Colaborador não encontrado.")
+
+    ultimo_registro = (
+        db.query(models.RegistroPonto)
+        .filter(models.RegistroPonto.colaborador_id == colaborador_id)
+        .order_by(models.RegistroPonto.timestamp_reg.desc())
+        .first()
+    )
+
+    tipo = "entrada" if not ultimo_registro or ultimo_registro.tipo_reg == "saida" else "saida"
+
+    agora = timestamp_manual or datetime.now()
+
+    novo_registro = models.RegistroPonto(
+        colaborador_id=colaborador_id,
+        tipo_reg=tipo,
+        timestamp_reg=agora,
+        data_reg=agora.date()
+    )
+
+    db.add(novo_registro)
+    db.commit()
+    db.refresh(novo_registro)
+
+    return novo_registro

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -5,16 +5,9 @@ from app.schemas import ColaboradorCreate
 from app.utils import gerar_senha, hash_senha
 
 def cadastrar_novo_colaborador(dados: ColaboradorCreate, db: Session) -> str:
-    """
-    Realiza a lógica de cadastro de um novo colaborador:
-    - Verifica se já existe CPF ou e-mail
-    - Gera senha
-    - Hasheia senha
-    - Persiste no banco
-    - Retorna a senha gerada
-    """
+
     existente = db.query(Colaborador).filter(
-        (Colaborador.cpf == dados.cpf) | (Colaborador.email == dados.email)
+        (Colaborador.cpf_col == dados.cpf) | (Colaborador.email_col == dados.email)
     ).first()
 
     if existente:
@@ -24,10 +17,10 @@ def cadastrar_novo_colaborador(dados: ColaboradorCreate, db: Session) -> str:
     senha_criptografada = hash_senha(senha)
 
     novo = Colaborador(
-        nome=dados.nome,
-        cpf=dados.cpf,
-        email=dados.email,
-        senha_hash=senha_criptografada
+        nome_col=dados.nome,
+        cpf_col=dados.cpf,
+        email_col=dados.email,
+        senha_col=senha_criptografada
     )
 
     db.add(novo)


### PR DESCRIPTION
_Este PR implementa a lógica completa de registro de ponto no backend_

As seguintes modificações foram feitas:
* Criação do modelo `RegistroPonto`;
* Lógica de alternância entre `entrada` e `saida` com base no último registro global (sem limitação por data);
* Suporte a registros que atravessam a meia-noite;
* Schema Pydantic para entrada e saída de dados;
* Rota principal (`POST /registro`);
* Rota de debug (`POST /registro/debug`) para testes manuais com `timestamp` customizado.

---

Esta funcionalidade é necessária para permitir o registro de horários dos colaboradores durante o evento, respeitando cenários reais como:

* Turnos noturnos que ultrapassam a meia-noite;
* Recontagem de tempo trabalhado em minutos (para exportação posterior).

#### 🧪 **Testes Manuais**

* Testes realizados com `Swagger` utilizando timestamps manuais e horários reais.
* Casos testados:

  * Entrada e saída no mesmo dia;
  * Entrada antes da meia-noite e saída após;
  * Múltiplos turnos no mesmo dia;
  * Erros com colaborador inexistente.

#### ⚠️ **Notas**

* A exportação para CSV será tratada em um PR futuro.
* Esta lógica está preparada para suportar o cálculo posterior de tempo total por turno com base nos pares `entrada`/`saida`.
